### PR TITLE
This commit adds a new GitHub Actions workflow to build the `rtop` an…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,122 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Build cpu_monitor
+      run: |
+        cd cpu_monitor
+        cargo build --release
+
+    - name: Set up Qt for Linux
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qt5-default
+
+    - name: Set up Qt for macOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install qt5
+        echo "/usr/local/opt/qt/bin" >> $GITHUB_PATH
+
+    - name: Set up Qt for Windows
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-qt5
+
+    - name: Build rtop on Linux/macOS
+      if: matrix.os != 'windows-latest'
+      run: |
+        cd Qt5
+        qmake
+        make
+      shell: bash
+
+    - name: Build rtop on Windows
+      if: matrix.os == 'windows-latest'
+      run: |
+        cd Qt5
+        qmake
+        mingw32-make
+      shell: msys2 {0}
+
+    - name: Package binaries
+      run: |
+        mkdir -p release
+        if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          cp Qt5/release/rtop.exe release/
+          cp cpu_monitor/target/release/cpu_monitor.exe release/
+          7z a -tzip rtop-${{ matrix.os }}.zip ./release/*
+        else
+          cp Qt5/rtop release/
+          cp cpu_monitor/target/release/cpu_monitor release/
+          tar -czvf rtop-${{ matrix.os }}.tar.gz ./release/*
+        fi
+      shell: bash
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: rtop-${{ matrix.os }}
+        path: rtop-${{ matrix.os }}.*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Get tag name
+        id: get_tag
+        run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_tag.outputs.TAG }}
+          release_name: Release ${{ steps.get_tag.outputs.TAG }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Assets
+        run: |
+          for dir in artifacts/*; do
+            if [ -d "$dir" ]; then
+              asset_path=$(find "$dir" -name "rtop-*.tar.gz" -o -name "rtop-*.zip")
+              asset_name=$(basename "$asset_path" | sed 's/-[a-z]*-latest//')
+              gh release upload ${{ steps.get_tag.outputs.TAG }} "$asset_path" --clobber
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…d `cpu_monitor` applications for Linux, Windows, and macOS. The workflow also creates a GitHub release and uploads the compiled binaries when a new tag is pushed.