### PR TITLE
This commit updates the GitHub Actions workflow to use `v4` of `actio…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -36,7 +37,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install qt5
-        echo "/usr/local/opt/qt/bin" >> $GITHUB_PATH
+        echo "$(brew --prefix qt5)/bin" >> $GITHUB_PATH
 
     - name: Set up Qt for Windows
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
…ns/upload-artifact` and `actions/download-artifact`, as `v3` is deprecated. It also updates `actions/checkout` to `v4` and fixes the deprecated `set-output` command.